### PR TITLE
Added touchscreen functionality to resizing in split pane view

### DIFF
--- a/astro-web/.gitignore
+++ b/astro-web/.gitignore
@@ -19,3 +19,6 @@ pnpm-debug.log*
 
 # macOS-specific files
 .DS_Store
+
+# github workflows
+.github

--- a/editioncrafter/src/component/SplitPaneView.js
+++ b/editioncrafter/src/component/SplitPaneView.js
@@ -109,8 +109,8 @@ class SplitPaneView extends Component {
 
   componentDidMount() {
     this.updateUI();
-    window.addEventListener('mousemove', this.onDrag);
-    window.addEventListener('mouseup', this.onEndDrag);
+    window.addEventListener('pointermove', this.onDrag);
+    window.addEventListener('pointerup', this.onEndDrag);
     window.addEventListener('resize', this.onResize);
     console.log(this.props);
     // Set the default width on mount
@@ -129,8 +129,8 @@ class SplitPaneView extends Component {
   }
 
   componentWillUnmount() {
-    window.removeEventListener('mousemove', this.onDrag);
-    window.removeEventListener('mouseup', this.onEndDrag);
+    window.removeEventListener('pointermove', this.onDrag);
+    window.removeEventListener('pointerup', this.onEndDrag);
     window.removeEventListener('resize', this.onResize);
   }
 
@@ -138,7 +138,7 @@ class SplitPaneView extends Component {
     const drawerIconClass = 'drawer-icon fas fa-caret-left fa-2x';
 
     return (
-      <div className={`divider ${position}_divider`} onMouseDown={() => this.onStartDrag(position)}>
+      <div className={`divider ${position}_divider`} onPointerDown={() => this.onStartDrag(position)}>
         <div className="drawer-button hidden" onClick={this.onDrawerButton}>
           <i className={drawerIconClass}> </i>
         </div>


### PR DESCRIPTION
### In this PR
- Updates the resizing functionality in the split pane view to (hopefully) work with touchscreens as well as mouse events.
- Adds the `.github` folder to `gitignore` so that it's easier to keep git workflows separate between this fork and upstream.