### PR TITLE
Improving the handling of component state changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@ __tests__/integration/editioncrafter/css/
 .cache/
 storybook-static
 .DS_Store
+.github

--- a/editioncrafter/src/component/DocumentView.js
+++ b/editioncrafter/src/component/DocumentView.js
@@ -61,12 +61,24 @@ const DocumentView = (props) => {
     
       return null;
     };
+
+    const reloadGlossary = async (glossary) => {
+      if (!glossary.loaded && glossary.URL) {
+        const glossaryData = fetch(glossary.URL).then((res) => (res.json()));
+        return glossaryData;
+      }
+    }
     // if the top-level component props have been updated such that the document initial state has been reinitialized, dispatch the loadDocument action with the new data
     if (!props.document.loaded) {
       reloadDocument(props.document).then((res) => {
-        console.log('reload', res);
         dispatchAction(props, 'DocumentActions.loadDocument', res);
       });
+    }
+    // update the glossary as well if necessary
+    if (!props.glossary.loaded && props.glossary.URL) {
+      reloadGlossary(props.glossary).then((res) => {
+        dispatchAction(props, 'GlossaryActions.loadGlossary', res);
+      })
     }
   }, [props.config]);
 
@@ -535,6 +547,7 @@ const DocumentView = (props) => {
 function mapStateToProps(state) {
   return {
     document: state.document,
+    glossary: state.glossary
   };
 }
 

--- a/editioncrafter/stories/EditionCrafter.stories.js
+++ b/editioncrafter/stories/EditionCrafter.stories.js
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect, useState } from 'react';
 import EditionCrafter from '../src/index';
 
 export const BowInTheCloud = () => (
@@ -57,25 +57,49 @@ export const IntervistePescatori = () => (
   />
 );
 
-export const MultiDocument = () => (
+export const OrnamentDesignTranslation = () => (
   <EditionCrafter
-    documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2 and eng-415-145a'
-    threePanel
+    documentName='Ornament : Design : Translation'
     documentInfo={{
-      FHL_007548733_TAOS_BAPTISMS_BATCH_2: {
-        documentName: 'Taos Baptisms Batch 2',
+      caryatidum: {
+        documentName: 'caryatidum',
         transcriptionTypes: {
-          translation: 'Translation',
-          transcription: 'Transcription',
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
-        iiifManifest: 'https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json',
+        iiifManifest: 'https://cu-mkp.github.io/odt-editioncrafter-data/texts/caryatidum/iiif/manifest.json',
       },
-      eng_415_145a: {
-        documentName: 'Eng 415-145a',
+      grotisch_fur_alle_kunstler: {
+        documentName: 'grotisch_fur_alle_kunstler',
         transcriptionTypes: {
-          'eng-415-145a': 'Transcription',
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
         },
-        iiifManifest: 'https://cu-mkp.github.io/bic-editioncrafter-data/eng-415-145a/iiif/manifest.json',
+        iiifManifest: 'https://cu-mkp.github.io/odt-editioncrafter-data/texts/grotisch_fur_alle_kunstler/iiif/manifest.json',
+      },
+      mansches_de_coutiaus: {
+        documentName: 'mansches_de_coutiaus',
+        transcriptionTypes: {
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/odt-editioncrafter-data/texts/mansches_de_coutiaus/iiif/manifest.json',
+      },
+      passio_verbigenae: {
+        documentName: 'passio_verbigenae',
+        transcriptionTypes: {
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/odt-editioncrafter-data/texts/passio_verbigenae/iiif/manifest.json',
+      },
+      veelderley_veranderinghe_van_grotissen: {
+        documentName: 'veelderley_veranderinghe_van_grotissen',
+        transcriptionTypes: {
+          'text-1': 'Text 1',
+          'text-2': 'Text 2',
+        },
+        iiifManifest: 'https://cu-mkp.github.io/odt-editioncrafter-data/texts/veelderley_veranderinghe_van_grotissen/iiif/manifest.json',
       },
     }}
   />
@@ -106,6 +130,29 @@ export const fullScreen = () => (
     />
   </div>
 )
+
+export const stateChange = () => {
+  const [manifest, setManifest] = useState('https://cu-mkp.github.io/editioncrafter/taos-baptisms-example/iiif/manifest.json');
+  const [glossary, setGlossary] = useState(undefined);
+
+  useEffect(() => {
+    setTimeout(() => {
+      setManifest('https://cu-mkp.github.io/dyngleyfamily-editioncrafter-data/O_8_35/iiif/manifest.json');
+      setGlossary('https://cu-mkp.github.io/editioncrafter-data/fr640_3r-3v-example/glossary.json');
+    }, 10000);
+  }, [])
+  
+  return (<EditionCrafter
+  documentName='FHL_007548733_TAOS_BAPTISMS_BATCH_2'
+  transcriptionTypes={{
+    translation: 'Translation',
+    transcription: 'Transcription',
+  }}
+  iiifManifest={manifest}
+  glossaryURL={glossary}
+/>)
+
+}
 
 export default {
   title: 'EditionCrafter',


### PR DESCRIPTION
### In this PR
- Adds a `useEffect` call to the `DocumentView` component to listen for changes to the config props passed to the component (e.g. the manifest link, document name, etc) and dispatch an action to the Redux store to reload the document and glossary data. This improves the previous behavior in this situation, namely just crashing and displaying a blank page.
- Also improves error handling in the case that one of the `folioID` values in the URL parameters is not actually included in the folio list; that pane will now redirect back to the grid view in that case.